### PR TITLE
Add `Connect` opcode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,20 @@ name = "io-uring-fd"
 version = "0.2.0-pre1"
 
 [[package]]
+name = "io-uring-op-connect"
+version = "0.0.1"
+dependencies = [
+ "capacity",
+ "io-uring",
+ "io-uring-bearer",
+ "io-uring-fd",
+ "io-uring-opcode",
+ "io-uring-owner",
+ "libc",
+ "ysockaddr",
+]
+
+[[package]]
 name = "io-uring-opcode"
 version = "0.2.0-pre2"
 dependencies = [
@@ -186,4 +200,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1dff32a2ce087283bec878419027cebd888760d8760b2941ad0843531dc9ec8"
 dependencies = [
  "no-std-compat",
+]
+
+[[package]]
+name = "ysockaddr"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0ffdfce5604de055884295a888f8476ef30c6ccf13dea0e45f06a7350be54ee"
+dependencies = [
+ "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
 [workspace]
-members = ["io-uring-bearer", "io-uring-epoll", "io-uring-opcode", "io-uring-fd", "io-uring-owner"]
+members = ["io-uring-bearer", "io-uring-epoll", "io-uring-opcode", "io-uring-fd", "io-uring-owner", "ops/*"]
 exclude = ["examples/*"]
 resolver = "2"

--- a/io-uring-bearer/Cargo.toml
+++ b/io-uring-bearer/Cargo.toml
@@ -26,6 +26,7 @@ io-uring-owner = { version = "0.2.0-pre1", path = "../io-uring-owner" }
 [features]
 default = []
 epoll = ["io-uring-opcode/epoll"]
+connect = ["io-uring-opcode/connect"]
 
 [package.metadata.docs.rs]
 features = ["epoll"]

--- a/io-uring-bearer/src/completion.rs
+++ b/io-uring-bearer/src/completion.rs
@@ -28,6 +28,9 @@ pub enum Completion<C> {
     RecvMulti(RecvMultiRec),
     /// SendZc
     SendZc(SendZcRec),
+    /// Gen + OpExtConnect impl
+    #[cfg(feature = "connect")]
+    Connect(C),    
     /// Gen + OpExtEpollCtl impl
     #[cfg(feature = "epoll")]
     EpollCtl(C),
@@ -43,6 +46,8 @@ impl<C: OpCompletion> Completion<C> {
             Completion::RecvMulti(r) => r.entry(),
             Completion::SendZc(r) => r.entry(),
             Completion::Op(r) => r.entry(),
+            #[cfg(feature = "connect")]
+            Completion::Connect(r) => r.entry(),            
             #[cfg(feature = "epoll")]
             Completion::EpollCtl(r) => r.entry(),
             _ => todo!(),
@@ -55,6 +60,8 @@ impl<C: OpCompletion> Completion<C> {
             Self::RecvMulti(ref recv_multi) => recv_multi.owner(),
             Self::SendZc(ref send_zc) => send_zc.owner(),
             Self::Op(ref impl_op) => impl_op.owner(),
+            #[cfg(feature = "connect")]
+            Self::Connect(ref impl_op) => impl_op.owner(),            
             #[cfg(feature = "epoll")]
             Self::EpollCtl(ref impl_op) => impl_op.owner(),
             _ => todo!(),
@@ -67,6 +74,8 @@ impl<C: OpCompletion> Completion<C> {
             Self::RecvMulti(ref mut recv_multi) => recv_multi.force_owner_kernel(),
             Self::SendZc(ref mut send_zc) => send_zc.force_owner_kernel(),
             Self::Op(ref mut impl_op) => impl_op.force_owner_kernel(),
+            #[cfg(feature = "connect")]
+            Self::Connect(ref mut impl_op) => impl_op.force_owner_kernel(),            
             #[cfg(feature = "epoll")]
             Self::EpollCtl(ref mut impl_op) => impl_op.force_owner_kernel(),
             _ => todo!(),

--- a/io-uring-bearer/src/uring.rs
+++ b/io-uring-bearer/src/uring.rs
@@ -7,6 +7,8 @@ mod recv;
 mod register;
 mod send_zc;
 
+#[cfg(feature = "connect")]
+mod connect;
 #[cfg(feature = "epoll")]
 mod epoll_ctl;
 

--- a/io-uring-bearer/src/uring/connect.rs
+++ b/io-uring-bearer/src/uring/connect.rs
@@ -1,0 +1,26 @@
+//! Interaface for pushing Connect implementing OpExtConnect
+
+use super::UringBearer;
+use crate::error::UringBearerError;
+use crate::Completion;
+use io_uring_opcode::OpExtConnect;
+use io_uring_opcode::{OpCode, OpCompletion};
+use slabbable::Slabbable;
+
+impl<C: core::fmt::Debug + Clone + OpCompletion> UringBearer<C> {
+    /// Push a Connect implementing OpCode +  traits (see io-uring-opcode)
+    pub fn push_connect<Op>(&mut self, op: Op) -> Result<usize, UringBearerError>
+    where
+        Op: OpCode<C> + OpExtConnect,
+    {
+        let key = self
+            .fd_slab
+            .take_next_with(Completion::Connect(op.submission()?))
+            .map_err(UringBearerError::Slabbable)?;
+
+        match self._push_to_completion(key) {
+            Err(e) => Err(e),
+            Ok(()) => Ok(key),
+        }
+    }
+}

--- a/io-uring-opcode/Cargo.toml
+++ b/io-uring-opcode/Cargo.toml
@@ -17,7 +17,8 @@ libc = "0.2.169"
 
 [features]
 default = []
+connect = []
 epoll = []
 
 [package.metadata.docs.rs]
-features = ["epoll"]
+features = ["connect", "epoll"]

--- a/io-uring-opcode/src/traits.rs
+++ b/io-uring-opcode/src/traits.rs
@@ -7,6 +7,11 @@ mod epoll_ctl;
 #[cfg(feature = "epoll")]
 pub use epoll_ctl::OpExtEpollCtl;
 
+#[cfg(feature = "connect")]
+mod connect;
+#[cfg(feature = "connect")]
+pub use connect::OpExtConnect;
+
 use core::pin::Pin;
 use io_uring_owner::Owner;
 

--- a/io-uring-opcode/src/traits/connect.rs
+++ b/io-uring-opcode/src/traits/connect.rs
@@ -1,0 +1,9 @@
+//! Connect extension trait
+
+/// Connect Expansion trait
+pub trait OpExtConnect {
+    /// Underlying RawFd
+    fn raw_fd(&self) -> std::os::fd::RawFd;
+//    /// Underlying libc::eooll_event
+//    fn ev(&self) -> &libc::epoll_event;
+}

--- a/ops/op-connect/Cargo.toml
+++ b/ops/op-connect/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "io-uring-op-connect"
+version = "0.0.1"
+edition = "2021"
+description = "Connect OpCode for io-uring-bearer"
+homepage = "https://github.com/yaws-rs/io_uring-utils/tree/main/op-connect"
+keywords = ["io", "uring"]
+license = "Apache-2.0/MIT"
+readme = "README.md"
+repository = "https://github.com/yaws-rs/io_uring-utils/tree/main/op-connect"
+categories = ["science"]
+
+[dependencies]
+io-uring = { version = "0.7" }
+libc = { version = "0.2", features = ["extra_traits"] }
+io-uring-opcode = { version = "0.2.0-pre1", path = "../../io-uring-opcode", features = ["connect"] }
+io-uring-bearer = { version = "0.2.0-pre1", path = "../../io-uring-bearer" }
+io-uring-fd = { version = "0.2.0-pre1", path = "../../io-uring-fd" }
+io-uring-owner = { version = "0.2.0-pre1", path = "../../io-uring-owner" }
+capacity = "0.1.2"
+ysockaddr = "0.1.1"
+
+[features]
+default = []

--- a/ops/op-connect/README.md
+++ b/ops/op-connect/README.md
@@ -1,0 +1,34 @@
+# io-uring-bearer Connect Op
+
+[![Discord chat][discord-badge]][discord-url]
+[![Crates.io](https://img.shields.io/crates/v/io-uring-op-connect.svg)](https://crates.io/crates/io-uring-op-connect)
+[![Docs](https://docs.rs/io-uring-op-connect/badge.svg)](https://docs.rs/io-uring-op-connect)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+![MSRV](https://img.shields.io/badge/MSRV-1.70.0-blue)
+
+TODO
+
+## Add
+
+```ignore
+cargo add io-uring-op-connect
+```
+
+## Example
+
+See [Examples](./examples) directory for the different use-cases.
+
+## License
+
+Licensed under either of:
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+
+[discord-badge]: https://img.shields.io/discord/934761553952141402.svg?logo=discord
+[discord-url]: https://discord.gg/rXVsmzhaZa

--- a/ops/op-connect/examples/connect.rs
+++ b/ops/op-connect/examples/connect.rs
@@ -1,0 +1,69 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::os::fd::AsRawFd;
+
+use io_uring_bearer::Completion;
+use io_uring_bearer::UringBearer;
+
+use capacity::{Capacity, Setting};
+use io_uring_bearer::BearerCapacityKind;
+
+//use io_uring_epoll::{EpollCtl, EpollUringHandler, HandledFd};
+
+#[derive(Clone, Debug)]
+pub struct MyCapacity;
+
+impl Setting<BearerCapacityKind> for MyCapacity {
+    fn setting(&self, v: &BearerCapacityKind) -> usize {
+        match v {
+            BearerCapacityKind::CoreQueue => 16,
+            BearerCapacityKind::RegisteredFd => 16,
+            BearerCapacityKind::PendingCompletions => 16,
+            BearerCapacityKind::Buffers => 16,
+            BearerCapacityKind::Futexes => 16,
+        }
+    }
+}
+
+fn main() {
+    let my_cap = Capacity::<MyCapacity, BearerCapacityKind>::with_planned(MyCapacity {});
+    let mut bearer = UringBearer::with_capacity(my_cap).unwrap();
+
+    let op_idx = bearer.push_op(connect).unwrap();
+
+    // Bearer to commit the pushed EpollCtl and wait it's sole completion.
+    bearer.submit_and_wait(1).unwrap();
+
+    #[derive(Debug)]
+    struct UserData {
+        e: u32,
+    }
+
+    let mut user = UserData { e: 0 };
+
+    // This is unsafe because forgetting the original submission record
+    // can lead to UB where the kernel still refers to it's address later.
+    /*
+    unsafe { bearer.handle_completions(&mut user, |user, entry, rec| {
+        match rec {
+            Completion::EpollEvent(e) => {
+                user.e += 1;
+                println!("EpollEvent => {:?} Entry => {:?}", e, entry);
+                // SAFETY: We retain the record and will not move it
+                SubmissionRecordStatus::Retain
+            }
+            _ => todo!(),
+        }
+    }) };
+    */
+
+    // This is safe since we are not touching the original submission record.
+    bearer
+        .completions(&mut user, |user, entry, rec| match rec {
+            Completion::Op(e) => {
+                user.e += 1;
+                println!("Completed => {:?} Entry => {:?}", e, entry);
+            }
+            _ => todo!(),
+        })
+        .unwrap();
+}

--- a/ops/op-connect/src/connect.rs
+++ b/ops/op-connect/src/connect.rs
@@ -1,0 +1,67 @@
+//! Connect Record
+
+use core::pin::Pin;
+
+use crate::error::ConnectError;
+
+use crate::HandledFd;
+use crate::RawFd;
+
+use io_uring_opcode::OpExtConnect;
+use io_uring_opcode::{OpCode, OpCompletion, OpError};
+use io_uring_owner::Owner;
+
+use ysockaddr::YSockAddrC;
+
+/// Connect Record
+#[derive(Clone, Debug, PartialEq)]
+pub struct Connect {
+    /// Current owner of the record
+    owner: Owner,
+    /// Related filehandle
+    fd: RawFd,
+}
+
+impl Connect {
+    /// Construct a new Connect
+    pub fn with_ysockaddr_c(ysaddr: YSockAddrC) -> Result<Self, ConnectError> {
+        Ok(Connect {
+            owner: Owner::Created,
+            fd: create_new_fd,
+        })
+    }
+}
+
+impl OpCompletion for Connect {
+    type Error = OpError;
+    fn entry(&self) -> io_uring::squeue::Entry {
+        io_uring::opcode::Connect::new(
+            io_uring::types::Fixed(self.epfd as u32),
+            io_uring::types::Fd(self.fd),
+        )
+        .build()
+    }
+    fn owner(&self) -> Owner {
+        self.owner.clone()
+    }
+    fn force_owner_kernel(&mut self) -> bool {
+        self.owner = Owner::Kernel;
+        true
+    }
+}
+
+impl OpCode<EpollCtl> for Connect {
+    fn submission(self) -> Result<Connect, OpError> {
+        Ok(self)
+    }
+    fn completion(&mut self, _: Pin<&mut Connect>) -> Result<(), OpError> {
+        todo!()
+    }
+}
+
+impl OpExtConnect for Connect {
+    /// Underlying RawFd
+    fn raw_fd(&self) -> RawFd {
+        self.fd
+    }
+}

--- a/ops/op-connect/src/error.rs
+++ b/ops/op-connect/src/error.rs
@@ -1,0 +1,18 @@
+//! Connect op Errors
+
+use core::fmt;
+use core::fmt::Display;
+
+use io_uring_bearer::error::UringBearerError;
+
+/// Connect Errors
+#[derive(Debug)]
+pub enum ConnectError {}
+
+impl Display for ConnectError {
+    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+impl std::error::Error for ConnectError {}

--- a/ops/op-connect/src/lib.rs
+++ b/ops/op-connect/src/lib.rs
@@ -1,0 +1,26 @@
+#![warn(
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
+#![doc = include_str!("../README.md")]
+
+//-----------------------------------------------
+// All Errors
+//-----------------------------------------------
+mod error;
+#[doc(inline)]
+pub use error::*;
+
+//-----------------------------------------------
+// Connect Record Types
+//-----------------------------------------------
+mod connect;
+pub use connect::Connect;
+
+//-----------------------------------------------
+// Misc crate-wide private types
+//-----------------------------------------------
+pub(crate) use std::os::fd::RawFd;


### PR DESCRIPTION
As extended trait implementation instead of embedded in bearer

This PR will show how to add individual opcodes in modular fashion